### PR TITLE
Disable answer false touch detection by default

### DIFF
--- a/java/com/android/incallui/answer/impl/classifier/HumanInteractionClassifier.java
+++ b/java/com/android/incallui/answer/impl/classifier/HumanInteractionClassifier.java
@@ -45,7 +45,7 @@ class HumanInteractionClassifier extends Classifier {
     mHistoryEvaluator = new HistoryEvaluator();
     mEnabled =
         ConfigProviderBindings.get(context)
-            .getBoolean(CONFIG_ANSWER_FALSE_TOUCH_DETECTION_ENABLED, true);
+            .getBoolean(CONFIG_ANSWER_FALSE_TOUCH_DETECTION_ENABLED, false);
 
     mStrokeClassifiers =
         new StrokeClassifier[] {


### PR DESCRIPTION
Remove that useless feature from 8.1. It's buggy on some devices.

To disable this feature on lockscreen, use https://github.com/Felvesthe/android_device_xiaomi_gemini/commit/0ddaaf888b697c5e440392980a10191571daab92